### PR TITLE
Fix checking of zarr or omero3d path

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,6 +27,7 @@ build: off
 build_script:
   # Install numpy first as javabridge needs it to already be installed
   - pip install "numpy==1.13.1"
+  - pip install "setuptools_scm==5.0.2"
   # Install pytest < 5.0.0 first as later versions may be included
   # in downstream dependencies
   - pip install "pytest<5.0.0"

--- a/cellprofiler/modules/loadimages.py
+++ b/cellprofiler/modules/loadimages.py
@@ -3222,7 +3222,7 @@ class LoadImagesImageProviderBase(cpimage.AbstractImageProvider):
         return True
 
     def get_full_name(self):
-        if self.is_zarr_path or self.is_omero3d_path:
+        if self.is_zarr_path() or self.is_omero3d_path():
             return self.get_url()
         self.cache_file()
         if self.__is_cached:

--- a/setup.py
+++ b/setup.py
@@ -70,6 +70,7 @@ setuptools.setup(
         "scikit-image==0.13.1",
         "scikit-learn==0.19.0",
         "scipy==1.0.1",
+        "setuptools_scm<=5.0.2",
         "zarr==2.3.2"
     ],
     license="BSD",


### PR DESCRIPTION
Illumination correction files are not read correctly because they are returned as URLs:
```
% cellprofiler -c -r -p Illum_Test_Pipe.cppipe --data-file ~/Downloads/image_list\ \(19\).csv
Times reported are CPU and Wall-clock times for each module
Error detected during run of module LoadData
Traceback (most recent call last):
  File "/Users/erindiel/CellProfiler/cellprofiler/pipeline.py", line 1770, in run_with_yield
    self.run_module(module, workspace)
  File "/Users/erindiel/CellProfiler/cellprofiler/pipeline.py", line 2022, in run_module
    module.run(workspace)
  File "/Users/erindiel/CellProfiler/cellprofiler/modules/loaddata.py", line 1139, in run
    image = image_set.get_image(image_name)
  File "/Users/erindiel/CellProfiler/cellprofiler/measurement.py", line 1620, in get_image
    image = matching_providers[0].provide_image(self)
  File "/Users/erindiel/CellProfiler/cellprofiler/modules/loadimages.py", line 3342, in provide_image
    img = np.load(self.get_full_name())
  File "/Users/erindiel/venvs/cellprofiler3.venv/lib/python2.7/site-packages/numpy/lib/npyio.py", line 370, in load
    fid = open(file, "rb")
IOError: [Errno 2] No such file or directory: 'file:/Users/erindiel/DAPI_Illum.npy'
Mon Aug 30 17:26:27 2021: Image # 1, module LoadData # 1: CPU_time = 0.01 secs, Wall_time = 0.01 secs
```

with this PR:
```
Mon Aug 30 17:28:08 2021: Image # 1, module LoadData # 1: CPU_time = 1.31 secs, Wall_time = 2.27 secs
Mon Aug 30 17:28:10 2021: Image # 1, module CorrectIlluminationApply # 2: CPU_time = 0.00 secs, Wall_time = 0.00 secs
Mon Aug 30 17:28:10 2021: Image # 1, module CorrectIlluminationApply # 3: CPU_time = 0.01 secs, Wall_time = 0.00 secs
```