### PR TITLE
Add zarr format support

### DIFF
--- a/cellprofiler/gui/pipelinecontroller.py
+++ b/cellprofiler/gui/pipelinecontroller.py
@@ -2116,7 +2116,7 @@ class PipelineController(object):
                         if path.path in desired:
                             message[0] = "\nProcessing " + path.path
                             desired.remove(path.path)
-                            if path.is_file():
+                            if path.is_file() or path.path.lower().endswith('.zarr'):
                                 urls.append(pathname2url(path.path))
                                 if len(urls) > 100:
                                     queue.put(urls)
@@ -2148,7 +2148,7 @@ class PipelineController(object):
                         break
 
                     message[0] = "\nProcessing " + pathname
-                    if os.path.isfile(pathname):
+                    if os.path.isfile(pathname) or pathname.lower().endswith('.zarr'):
                         urls.append(pathname2url(pathname))
                         if len(urls) > 100:
                             queue.put(urls)


### PR DESCRIPTION
Requires glencoesoftware/Core#4

This PR introduces OME-ZARR support to CellProfiler. To achieve this I've injected a format-specific loader into the file reading sequence, which will live in `cellprofiler_core/utilities/zarr.py`. This is designed to mimic the bioformats reader API and so should function as a drop-in replacement whenever a zarr is added.

The primary issue for reading these files is that just providing series and index is not sufficient to properly index multichannel, timelapse or volumetric zarr arrays. To address this I've added functionality to fetch Z, C and T parameters from stored metadata and pass them into the image providers. While these parameters will also be sent to bioformats readers, if the documentation is correct the index parameter should take priority when working with those files.

Extracting metadata from file headers is necessary to pull data out of the zarrs. Because of this the zarr currently must contain an OME-XML file describing it's contents. This should allow both normal and HCS-layout zarrs to be read. I did add a system to attempt to generate the XML data when working with zarrs which are missing the file, but this will only work reliably on non-HCS zarrs.

In some initial testing it seems that we can read zarr data from S3 URLs without needing to download it to local storage, but it seems to be rather slow. This might be something that can be improved, but for now it seems to work.

I believe this should work with 2d and 3d images, plus with the LoadData module. When working with 3D images in volumetric mode it's probably going to be necessary to filter down the image plane list to just those with Z=0. The Z parameter is ignored in 3D mode but the Metadata mode has no means to ignore the extra frames when extracting from file headers.