### PR TITLE
Pin to macos 11

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ macos-11, windows-2019 ]
+        os: [ macos-12, windows-2019 ]
         python-version: [ "3.8" ]
       fail-fast: false
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ macos-latest, windows-2019 ]
+        os: [ macos-11, windows-2019 ]
         python-version: [ "3.8" ]
       fail-fast: false
     steps:


### PR DESCRIPTION
Macos 14 envs appear to be M1 machines, which we can't use.

Update: macos-11 doesn't play well with brew.